### PR TITLE
Removed duplicate line

### DIFF
--- a/server-side-rendering/src/ClientApp.jsx
+++ b/server-side-rendering/src/ClientApp.jsx
@@ -6,6 +6,5 @@ hydrateRoot(
   document.getElementById("root"),
   <BrowserRouter>
     <App />
-  </BrowserRouter>,
-  document.getElementById("root")
+  </BrowserRouter>
 );


### PR DESCRIPTION
The line `document.getElementById("root")` was appeared twice. I removed it to match what's done in the lesson.