### PR TITLE
Use empty alt text for Pets component 'hero' image

### DIFF
--- a/07-component-composition/src/Pet.jsx
+++ b/07-component-composition/src/Pet.jsx
@@ -9,7 +9,7 @@ const Pet = (props) => {
   return (
     <a href={`/details/${id}`} className="pet">
       <div className="image-container">
-        <img src={hero} alt={name} />
+        <img src={hero} alt="" />
       </div>
       <div className="info">
         <h1>{name}</h1>

--- a/08-react-router/src/Pet.jsx
+++ b/08-react-router/src/Pet.jsx
@@ -11,7 +11,7 @@ const Pet = (props) => {
   return (
     <Link to={`/details/${id}`} className="pet">
       <div className="image-container">
-        <img src={hero} alt={name} />
+        <img src={hero} alt="" />
       </div>
       <div className="info">
         <h1>{name}</h1>

--- a/09-react-query/src/Pet.jsx
+++ b/09-react-query/src/Pet.jsx
@@ -11,7 +11,7 @@ const Pet = (props) => {
   return (
     <Link to={`/details/${id}`} className="pet">
       <div className="image-container">
-        <img src={hero} alt={name} />
+        <img src={hero} alt="" />
       </div>
       <div className="info">
         <h1>{name}</h1>

--- a/10-uncontrolled-forms/src/Pet.jsx
+++ b/10-uncontrolled-forms/src/Pet.jsx
@@ -11,7 +11,7 @@ const Pet = (props) => {
   return (
     <Link to={`/details/${id}`} className="pet">
       <div className="image-container">
-        <img src={hero} alt={name} />
+        <img src={hero} alt="" />
       </div>
       <div className="info">
         <h1>{name}</h1>

--- a/11-class-components/src/Pet.jsx
+++ b/11-class-components/src/Pet.jsx
@@ -11,7 +11,7 @@ const Pet = (props) => {
   return (
     <Link to={`/details/${id}`} className="pet">
       <div className="image-container">
-        <img src={hero} alt={name} />
+        <img src={hero} alt="" />
       </div>
       <div className="info">
         <h1>{name}</h1>

--- a/12-error-boundaries/src/Pet.jsx
+++ b/12-error-boundaries/src/Pet.jsx
@@ -11,7 +11,7 @@ const Pet = (props) => {
   return (
     <Link to={`/details/${id}`} className="pet">
       <div className="image-container">
-        <img src={hero} alt={name} />
+        <img src={hero} alt="" />
       </div>
       <div className="info">
         <h1>{name}</h1>

--- a/13-portals-and-refs/src/Pet.jsx
+++ b/13-portals-and-refs/src/Pet.jsx
@@ -11,7 +11,7 @@ const Pet = (props) => {
   return (
     <Link to={`/details/${id}`} className="pet">
       <div className="image-container">
-        <img src={hero} alt={name} />
+        <img src={hero} alt="" />
       </div>
       <div className="info">
         <h1>{name}</h1>

--- a/14-context/src/Pet.jsx
+++ b/14-context/src/Pet.jsx
@@ -11,7 +11,7 @@ const Pet = (props) => {
   return (
     <Link to={`/details/${id}`} className="pet">
       <div className="image-container">
-        <img src={hero} alt={name} />
+        <img src={hero} alt="" />
       </div>
       <div className="info">
         <h1>{name}</h1>

--- a/code-splitting/src/Pet.jsx
+++ b/code-splitting/src/Pet.jsx
@@ -11,7 +11,7 @@ const Pet = (props) => {
   return (
     <Link to={`/details/${id}`} className="pet">
       <div className="image-container">
-        <img src={hero} alt={name} />
+        <img src={hero} alt="" />
       </div>
       <div className="info">
         <h1>{name}</h1>

--- a/redux/src/Pet.jsx
+++ b/redux/src/Pet.jsx
@@ -11,7 +11,7 @@ const Pet = (props) => {
   return (
     <Link to={`/details/${id}`} className="pet">
       <div className="image-container">
-        <img src={hero} alt={name} />
+        <img src={hero} alt="" />
       </div>
       <div className="info">
         <h1>{name}</h1>

--- a/server-side-rendering/src/Pet.jsx
+++ b/server-side-rendering/src/Pet.jsx
@@ -11,7 +11,7 @@ const Pet = (props) => {
   return (
     <Link to={`/details/${id}`} className="pet">
       <div className="image-container">
-        <img src={hero} alt={name} />
+        <img src={hero} alt="" />
       </div>
       <div className="info">
         <h1>{name}</h1>

--- a/tailwindcss/src/Pet.jsx
+++ b/tailwindcss/src/Pet.jsx
@@ -11,7 +11,7 @@ const Pet = (props) => {
   return (
     <Link to={`/details/${id}`} className="relative block">
       <div>
-        <img src={hero} alt={name} />
+        <img src={hero} alt="" />
       </div>
       <div className="absolute bottom-0 left-0 bg-gradient-to-tr from-white to-transparent pr-2 pt-2">
         <h1>{name}</h1>

--- a/testing/src/Pet.jsx
+++ b/testing/src/Pet.jsx
@@ -11,7 +11,7 @@ const Pet = (props) => {
   return (
     <Link to={`/details/${id}`} className="pet">
       <div className="image-container">
-        <img data-testid="thumbnail" src={hero} alt={name} />
+        <img data-testid="thumbnail" src={hero} alt="" />
       </div>
       <div className="info">
         <h1>{name}</h1>

--- a/transitions/src/Pet.jsx
+++ b/transitions/src/Pet.jsx
@@ -11,7 +11,7 @@ const Pet = (props) => {
   return (
     <Link to={`/details/${id}`} className="pet">
       <div className="image-container">
-        <img src={hero} alt={name} />
+        <img src={hero} alt="" />
       </div>
       <div className="info">
         <h1>{name}</h1>

--- a/typescript-1/src/Pet.jsx
+++ b/typescript-1/src/Pet.jsx
@@ -11,7 +11,7 @@ const Pet = (props) => {
   return (
     <Link to={`/details/${id}`} className="pet">
       <div className="image-container">
-        <img src={hero} alt={name} />
+        <img src={hero} alt="" />
       </div>
       <div className="info">
         <h1>{name}</h1>

--- a/typescript-2/src/Pet.jsx
+++ b/typescript-2/src/Pet.jsx
@@ -11,7 +11,7 @@ const Pet = (props) => {
   return (
     <Link to={`/details/${id}`} className="pet">
       <div className="image-container">
-        <img src={hero} alt={name} />
+        <img src={hero} alt="" />
       </div>
       <div className="info">
         <h1>{name}</h1>

--- a/typescript-3/src/Pet.tsx
+++ b/typescript-3/src/Pet.tsx
@@ -20,7 +20,7 @@ const Pet = (props: IProps) => {
   return (
     <Link to={`/details/${id}`} className="pet">
       <div className="image-container">
-        <img src={hero} alt={name} />
+        <img src={hero} alt="" />
       </div>
       <div className="info">
         <h1>{name}</h1>

--- a/typescript-4/src/Pet.tsx
+++ b/typescript-4/src/Pet.tsx
@@ -20,7 +20,7 @@ const Pet = (props: IProps) => {
   return (
     <Link to={`/details/${id}`} className="pet">
       <div className="image-container">
-        <img src={hero} alt={name} />
+        <img src={hero} alt="" />
       </div>
       <div className="info">
         <h1>{name}</h1>


### PR DESCRIPTION
From step 7 onwards, the `Pet` component implements this code inside an `<a>` or `<Link>` element:
```
<div className="image-container">
  <img src={hero} alt={hero} />
  </div>
<div className="info">
  <h1>{name}</h1>
  <h2>{`${animal} — ${breed} — ${location}`}</h2>
</div>
```

The `name` prop used for the image alt text is duplicated in the contents of the adjacent H1, so my suggested change is to set the alt text attribute to empty:

```
<div className="image-container">
  <img src={hero} alt="" />
  </div>
<div className="info">
  <h1>{name}</h1>
  <h2>{`${animal} — ${breed} — ${location}`}</h2>
</div>
```

This will have the effect of making the image effectively invisible to screen reader users, but the current consensus is that this is desirable behaviour when the alt text would otherwise be duplicating adjacent text. In an ideal world the alt text would accurately describe the contents of the image (e.g. colour, fur type, position, background elements) of each pet, but 

The `Carousel` component has a similar issue with redundant alt text (`alt="animal"` and `alt="animal thumbnail"`), but setting the alt text to blank would essentially make the carousel entirely empty to screen reader users, so I don't think this is addressable without reworking the entire component.

References:
https://webaim.org/techniques/alttext/#context
https://rocketvalidator.com/accessibility-validation/axe/4.7/image-redundant-alt