### PR TITLE
Add eslint rule to ignore underscore in hooks

### DIFF
--- a/14-context/.eslintrc.json
+++ b/14-context/.eslintrc.json
@@ -9,7 +9,10 @@
   ],
   "rules": {
     "react/prop-types": 0,
-    "react/react-in-jsx-scope": 0
+    "react/react-in-jsx-scope": 0,
+    "no-unused-vars": ["error", {
+      "varsIgnorePattern": "^_"
+    }]
   },
   "plugins": ["react", "import", "jsx-a11y"],
   "parserOptions": {

--- a/14-context/src/Details.jsx
+++ b/14-context/src/Details.jsx
@@ -12,7 +12,6 @@ const Details = () => {
   const [showModal, setShowModal] = useState(false);
   const navigate = useNavigate();
   const results = useQuery(["details", id], fetchPet);
-  // eslint-disable-next-line no-unused-vars
   const [_, setAdoptedPet] = useContext(AdoptedPetContext);
 
   if (results.isLoading) {


### PR DESCRIPTION
Removes the ESLint error created and discussed at approximately 2:52 in the [Context Q&A video](https://frontendmasters.com/courses/complete-react-v8/context-q-a/) under the Special Case React Tools section of the Complete Intro to React, v8 Frontend Masters course.

This PR adds:

```
"no-unused-vars": ["error", {
  "varsIgnorePattern": "^_"
}]
```

to the `.eslintrc.json` `"rules"` object.

which allows us to remove:

`// eslint-disable-next-line no-unused-vars`

from line 15 of the [`14-context/src/Details.jsx`](https://github.com/ohhheyyyy/citr-v8-project/blob/main/14-context/src/Details.jsx#L15) file.